### PR TITLE
strings/newLineToBr: Properly replace windows/mac linebreaks as well

### DIFF
--- a/src/swag.strings.coffee
+++ b/src/swag.strings.coffee
@@ -37,4 +37,4 @@ Handlebars.registerHelper 'center', (str, spaces) ->
     "#{space}#{str}#{space}"
 
 Handlebars.registerHelper 'newLineToBr', (str) ->
-    str.replace /\n/g, '<br>'
+    str.replace /\r?\n|\r/g, '<br>'


### PR DESCRIPTION
Replace \r\n (win) and \r (mac) as well as good ol' \n
