### PR TITLE
Random test failure in dates_test

### DIFF
--- a/test/dates_test.coffee
+++ b/test/dates_test.coffee
@@ -18,7 +18,8 @@ describe 'now', ->
             source   = '{{now}}'
             template = Handlebars.compile(source)
 
-            template().should.equal new Date()
+            currentTime = new Date().getTime()
+            template().should.be.within(currentTime - 5, currentTime + 1)
 
 describe 'timeago', ->
     describe '{{timeago date}}', ->


### PR DESCRIPTION
I was having an issue where the test for {{now}} would periodically fail because of millisecond(s) difference between when the template was compiled and the assertion. I wasn't sure of the best way to avoid this, but this simple check that the time is included in a range of the last 5 milliseconds has worked well for me.
