### PR TITLE
Changed handlebars repo and updated version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
         "bower_components"
     ],
     "dependencies": {
-        "handlebars.js": "1.1.x"
+        "handlebars": "1.3.x"
     }
 }


### PR DESCRIPTION
Handlebars has a separate bower repo as of version 1.1.x: wycats/handlebars.js#655

Closes #35 - version number updated to 1.3.x in bower.json.
