### PR TITLE
Bug in sanatizing parameters for 'is' helper

### DIFF
--- a/src/swag.comparisons.coffee
+++ b/src/swag.comparisons.coffee
@@ -1,5 +1,5 @@
 Swag.addHelper 'is', (value, test, options) ->
-    unless (Utils.isHandlebarsSpecific value) and (Utils.isHandlebarsSpecific value)
+    unless (Utils.isHandlebarsSpecific value) and (Utils.isHandlebarsSpecific test)
         value = Utils.result value
         test = Utils.result test
         if value and value is test then options.fn this else options.inverse this


### PR DESCRIPTION
Swag should be checking both `value` and `test` to make sure they are handlebarsSpecific before executing the helper. The operation was redundant before (just checking `value` twice).
