### PR TITLE
Fix ul and ol helpers

### DIFF
--- a/lib/swag.js
+++ b/lib/swag.js
@@ -1032,12 +1032,14 @@
   };
 
   Swag.addHelper('ul', function(context, options) {
+    if (Utils.isUndefined(context)) { return "<ul></ul>"; }
     return ("<ul " + (HTML.parseAttributes(options.hash)) + ">") + context.map(function(item) {
       return "<li>" + (options.fn(Utils.result(item))) + "</li>";
     }).join('\n') + "</ul>";
   });
 
   Swag.addHelper('ol', function(context, options) {
+    if (Utils.isUndefined(context)) { return "<ol></ol>"; }
     return ("<ol " + (HTML.parseAttributes(options.hash)) + ">") + context.map(function(item) {
       return "<li>" + (options.fn(Utils.result(item))) + "</li>";
     }).join('\n') + "</ol>";


### PR DESCRIPTION
Not testing for missing data in the ul and ol helpers causes the template to not render. This change fixes it.
